### PR TITLE
feat: Move to OpenAI API Spec and add manual GitHub username mapping with admin review

### DIFF
--- a/CodeReviewAgentApp.ts
+++ b/CodeReviewAgentApp.ts
@@ -29,7 +29,7 @@ import { ISetting } from "@rocket.chat/apps-engine/definition/settings";
 // Import services
 import { PRService } from "./src/services/PRService";
 import { GitHubAPIService } from "./src/services/GitHubAPIService";
-import { GeminiService } from "./src/services/GeminiService";
+import { AIService } from "./src/services/AIService";
 import { CodeownersService } from "./src/services/CodeownersService";
 import { SpamDetectionService } from "./src/services/SpamDetectionService";
 import { ReviewerMatchingService } from "./src/services/ReviewerMatchingService";
@@ -64,7 +64,7 @@ export class CodeReviewAgentApp extends App implements IAppInterface {
   // Services
   private prService?: PRService;
   private githubService?: GitHubAPIService;
-  private geminiService?: GeminiService;
+  private aiService?: AIService;
   private codeownersService?: CodeownersService;
   private spamDetectionService?: SpamDetectionService;
   private reviewerMatchingService?: ReviewerMatchingService;
@@ -100,11 +100,11 @@ export class CodeReviewAgentApp extends App implements IAppInterface {
     return this.githubService;
   }
 
-  public getGeminiService(): GeminiService {
-    if (!this.geminiService) {
-      this.geminiService = new GeminiService(this);
+  public getAIService(): AIService {
+    if (!this.aiService) {
+      this.aiService = new AIService(this);
     }
-    return this.geminiService;
+    return this.aiService;
   }
 
   public getCodeownersService(): CodeownersService {
@@ -261,7 +261,7 @@ ${quickReminder}Need help? Use \`/code-review-agent help\` for available command
       http,
       this.getLogger(),
       () => {
-        this.geminiService = undefined;
+        this.aiService = undefined;
         this.spamDetectionService = undefined;
         this.reviewerMatchingService = undefined;
       },
@@ -576,19 +576,19 @@ ${quickReminder}Need help? Use \`/code-review-agent help\` for available command
         }
       }
 
-      // Validate Gemini settings
+      // Validate AI settings
       const apiKey = await settingsReader.getValueById(
-        AppSettingsEnum.GEMINI_API_KEY_ID
+        AppSettingsEnum.AI_PROVIDER_API_KEY_ID
       );
       if (!apiKey || !ValidationHelper.isValidApiKey(apiKey)) {
-        errors.push("Invalid Gemini API key");
+        errors.push("Invalid AI provider API key");
       }
 
       const model = await settingsReader.getValueById(
-        AppSettingsEnum.GEMINI_MODEL_ID
+        AppSettingsEnum.AI_MODEL_ID
       );
       if (!model) {
-        errors.push("Gemini model selection is required");
+        errors.push("AI model selection is required");
       }
     } catch (error) {
       errors.push(`Settings validation error: ${error.message}`);

--- a/src/commands/CodeReviewAgentCommand.ts
+++ b/src/commands/CodeReviewAgentCommand.ts
@@ -16,6 +16,7 @@ import { authorize } from "./subcommands/authorize";
 import { handleSpamCommand } from "./subcommands/spam";
 import { handleStatusCommand } from "./subcommands/status";
 import { handleTriggerCommand } from "./subcommands/trigger";
+import { handleUsernameCommand } from "./subcommands/username";
 import { sendNotification } from "../helpers/message";
 
 export class CodeReviewAgentCommand implements ISlashCommand {
@@ -89,6 +90,17 @@ export class CodeReviewAgentCommand implements ISlashCommand {
           persistence
         );
         break;
+      case "username":
+        await handleUsernameCommand(
+          this.app,
+          read,
+          modify,
+          context.getSender(),
+          context.getRoom(),
+          persistence,
+          args
+        );
+        break;
       case "help":
       default:
         await this.displayAppHelpMessage(
@@ -124,7 +136,10 @@ export class CodeReviewAgentCommand implements ISlashCommand {
 • \`spam list\` - List pending spam reviews
 • \`spam approve <pr_id>\` - Approve flagged PR
 • \`spam reject <pr_id>\` - Reject as spam
-• \`spam ignore <pr_id>\` - Ignore PR`
+• \`spam ignore <pr_id>\` - Ignore PR
+• \`username\` - List pending username mappings
+• \`username approve <id>\` - Approve username mapping
+• \`username reject <id> [reason]\` - Reject username mapping`
       : "";
 
     const text = `🤖 **Code Review Agent Commands**
@@ -132,17 +147,22 @@ export class CodeReviewAgentCommand implements ISlashCommand {
 **📋 General Commands:**
 • \`help\` - Show this help message
 • \`auth\` - Authenticate with GitHub
+• \`username <github-username>\` - Submit GitHub username for review
 • \`status\` - Show app status and activity${adminCommands}
 
 **💡 Examples:**
 • \`/code-review-agent auth\`
-• \`/code-review-agent status\`${isAdmin ? "\n• `/code-review-agent spam`" : ""}
+• \`/code-review-agent username octocat\`
+• \`/code-review-agent status\`${isAdmin ? "\n• `/code-review-agent spam`\n• `/code-review-agent username`" : ""}
 
 **🚀 About:**
 This app helps streamline code reviews by:
 • 🤖 AI-powered spam detection
 • 👥 Smart reviewer matching
 • 🔔 Automated notifications
+
+**🔗 Account Linking:**
+You can link your GitHub account via OAuth (\`auth\`) or submit your username for admin review (\`username\`).
 
 Need help? Check the app settings for configuration options.`;
 

--- a/src/commands/subcommands/username.ts
+++ b/src/commands/subcommands/username.ts
@@ -1,0 +1,605 @@
+// src/commands/subcommands/username.ts
+import {
+  IModify,
+  IRead,
+  IPersistence,
+  IPersistenceRead,
+} from "@rocket.chat/apps-engine/definition/accessors";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
+import { IAppInterface } from "../../interfaces/IAppInterface";
+import { 
+  PendingUserMappingPersistence, 
+  PendingUserMapping 
+} from "../../persistence/PendingUserMappingPersistence";
+import { UserMappingPersistence, UserMapping } from "../../persistence/UserMappingPersistence";
+import { sendNotification, sendDirectMessage } from "../../helpers/message";
+import { isUserHighHierarchy } from "../../helpers/message";
+import { LayoutBlock } from "@rocket.chat/ui-kit";
+import {
+  getSectionBlock,
+  getActionsBlock,
+  getButton,
+  getDividerBlock,
+  getContextBlock,
+} from "../../helpers/blockBuilder";
+
+export async function handleUsernameCommand(
+  app: IAppInterface,
+  read: IRead,
+  modify: IModify,
+  user: IUser,
+  room: IRoom,
+  persistence: IPersistence,
+  args: string[]
+): Promise<void> {
+  const action = args[0]?.toLowerCase();
+  const persistenceRead = read.getPersistenceReader();
+
+  switch (action) {
+    case "list":
+      await handleListPendingMappings(
+        app,
+        read,
+        modify,
+        user,
+        room,
+        persistence,
+        persistenceRead
+      );
+      break;
+
+    case "approve":
+      await handleMappingAction(
+        app,
+        read,
+        modify,
+        user,
+        room,
+        persistence,
+        persistenceRead,
+        args[1],
+        "approve"
+      );
+      break;
+
+    case "reject":
+      await handleMappingAction(
+        app,
+        read,
+        modify,
+        user,
+        room,
+        persistence,
+        persistenceRead,
+        args[1],
+        "reject",
+        args.slice(2).join(" ") // rejection reason
+      );
+      break;
+
+    case "help":
+      await handleUsernameHelp(modify, user, room);
+      break;
+
+    case undefined:
+      if (!isUserHighHierarchy(user)) {
+        await sendNotification({
+          modify: modify,
+          user: user,
+          room: room,
+          message: "❌ **Missing GitHub username**\n\nUsage: `/code-review-agent username <github-username>`",
+        });
+        return;
+      }
+      // Default action for admins is list
+      await handleListPendingMappings(
+        app,
+        read,
+        modify,
+        user,
+        room,
+        persistence,
+        persistenceRead
+      );
+      break;
+
+    default:
+      // Treat as GitHub username submission
+      await handleUsernameSubmission(
+        app,
+        read,
+        modify,
+        user,
+        room,
+        persistence,
+        persistenceRead,
+        action // The "action" is actually the GitHub username
+      );
+      break;
+  }
+}
+
+/**
+ * Handle user submission of GitHub username
+ */
+async function handleUsernameSubmission(
+  app: IAppInterface,
+  read: IRead,
+  modify: IModify,
+  user: IUser,
+  room: IRoom,
+  persistence: IPersistence,
+  persistenceRead: IPersistenceRead,
+  githubUsername: string
+): Promise<void> {
+  try {
+    // Validate GitHub username format
+    if (!githubUsername || !/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i.test(githubUsername)) {
+      await sendNotification({
+        modify: modify,
+        user: user,
+        room: room,
+        message: "❌ **Invalid GitHub username format**\n\nGitHub usernames can only contain alphanumeric characters and hyphens, and cannot start or end with a hyphen.",
+      });
+      return;
+    }
+
+    // Check if user already has a mapping
+    const existingMapping = await UserMappingPersistence.getUserMapping(user.id, persistenceRead);
+    if (existingMapping) {
+      await sendNotification({
+        modify: modify,
+        user: user,
+        room: room,
+        message: `❌ **Already mapped**\n\nYour RocketChat account is already linked to GitHub user @${existingMapping.githubUsername}.\n\nTo change this mapping, please contact an administrator.`,
+      });
+      return;
+    }
+
+    // Check if user already has a pending request
+    const existingPendingMapping = await PendingUserMappingPersistence.getPendingUserMappingByRocketChatUserId(user.id, persistenceRead);
+    if (existingPendingMapping) {
+      await sendNotification({
+        modify: modify,
+        user: user,
+        room: room,
+        message: `⏳ **Request already pending**\n\nYou already have a pending mapping request for GitHub user @${existingPendingMapping.githubUsername}.\n\nPlease wait for admin review before submitting a new request.`,
+      });
+      return;
+    }
+
+    // Check if GitHub username is already mapped to another user
+    const existingGithubMapping = await UserMappingPersistence.getUserMappingByGithubUsername(githubUsername, persistenceRead);
+    if (existingGithubMapping) {
+      await sendNotification({
+        modify: modify,
+        user: user,
+        room: room,
+        message: `❌ **GitHub username already mapped**\n\nThe GitHub username @${githubUsername} is already linked to another RocketChat user.\n\nIf you believe this is an error, please contact an administrator.`,
+      });
+      return;
+    }
+
+    // Check if GitHub username has a pending request
+    const existingPendingGithubMapping = await PendingUserMappingPersistence.getPendingUserMappingByGithubUsername(githubUsername, persistenceRead);
+    if (existingPendingGithubMapping) {
+      await sendNotification({
+        modify: modify,
+        user: user,
+        room: room,
+        message: `❌ **GitHub username has pending request**\n\nThe GitHub username @${githubUsername} already has a pending mapping request.\n\nPlease choose a different username or wait for the existing request to be processed.`,
+      });
+      return;
+    }
+
+    // Fetch GitHub user data
+    const githubService = app.getGitHubService();
+    let githubUserData;
+    try {
+      githubUserData = await githubService.getUserInfo(githubUsername);
+    } catch (error) {
+      if (error.message.includes('404')) {
+        await sendNotification({
+          modify: modify,
+          user: user,
+          room: room,
+          message: `❌ **GitHub user not found**\n\nThe GitHub username @${githubUsername} does not exist.\n\nPlease check the spelling and try again.`,
+        });
+        return;
+      }
+      throw error;
+    }
+
+    // Create pending mapping request
+    const pendingMapping: PendingUserMapping = {
+      id: `${user.id}_${Date.now()}`,
+      rocketchatUserId: user.id,
+      rocketchatUsername: user.username,
+      githubUsername: githubUserData.login,
+      githubUserId: githubUserData.id,
+      githubMetadata: {
+        name: githubUserData.name,
+        company: githubUserData.company,
+        location: githubUserData.location,
+        bio: githubUserData.bio,
+        publicRepos: githubUserData.public_repos,
+        followers: githubUserData.followers,
+        following: githubUserData.following,
+        createdAt: githubUserData.created_at,
+        avatarUrl: githubUserData.avatar_url,
+        htmlUrl: githubUserData.html_url,
+      },
+      status: 'pending',
+      requestedAt: new Date(),
+    };
+
+    await PendingUserMappingPersistence.savePendingUserMapping(pendingMapping, persistence);
+
+    await sendNotification({
+      modify: modify,
+      user: user,
+      room: room,
+      message: `✅ **Username mapping request submitted**\n\nYour request to link your RocketChat account with GitHub user @${githubUserData.login} has been submitted for admin review.\n\nYou'll be notified via direct message once your request is processed.`,
+    });
+
+    app.getLogger().info(`Username mapping request submitted: ${user.username} -> @${githubUsername}`);
+
+  } catch (error) {
+    app.getLogger().error(`Failed to submit username mapping: ${error.message}`);
+    await sendNotification({
+      modify: modify,
+      user: user,
+      room: room,
+      message: `❌ **Error submitting username mapping:** ${error.message}`,
+    });
+  }
+}
+
+/**
+ * List pending username mapping requests (Admin only)
+ */
+async function handleListPendingMappings(
+  app: IAppInterface,
+  read: IRead,
+  modify: IModify,
+  user: IUser,
+  room: IRoom,
+  persistence: IPersistence,
+  persistenceRead: IPersistenceRead
+): Promise<void> {
+  // Check if user has admin permissions
+  if (!isUserHighHierarchy(user)) {
+    await sendNotification({
+      modify: modify,
+      user: user,
+      room: room,
+      message: "❌ **Access Denied**\n\nYou don't have permission to view pending username mappings. This feature is restricted to administrators.\n\nTo submit your own GitHub username, use: `/code-review-agent username <github-username>`",
+    });
+    return;
+  }
+
+  try {
+    const pendingMappings = await PendingUserMappingPersistence.getPendingUserMappings(persistenceRead);
+
+    if (pendingMappings.length === 0) {
+      await sendNotification({
+        modify: modify,
+        user: user,
+        room: room,
+        message: "✅ **No Pending Username Mappings**\n\nAll username mapping requests have been processed! No requests require admin attention.",
+      });
+      return;
+    }
+
+    const message = buildMappingListMessage(pendingMappings);
+    const blocks = buildMappingListBlocks(pendingMappings);
+
+    await sendNotification({
+      modify: modify,
+      user: user,
+      room: room,
+      message: message,
+      blocks: blocks,
+    });
+  } catch (error) {
+    app.getLogger().error(`Failed to list pending mappings: ${error.message}`);
+    await sendNotification({
+      modify: modify,
+      user: user,
+      room: room,
+      message: `❌ **Error retrieving pending mappings:** ${error.message}`,
+    });
+  }
+}
+
+/**
+ * Handle mapping actions (approve/reject)
+ */
+async function handleMappingAction(
+  app: IAppInterface,
+  read: IRead,
+  modify: IModify,
+  user: IUser,
+  room: IRoom,
+  persistence: IPersistence,
+  persistenceRead: IPersistenceRead,
+  mappingId: string,
+  action: "approve" | "reject",
+  rejectionReason?: string
+): Promise<void> {
+  // Check if user has admin permissions
+  if (!isUserHighHierarchy(user)) {
+    await sendNotification({
+      modify: modify,
+      user: user,
+      room: room,
+      message: "❌ **Access Denied**\n\nYou don't have permission to review username mappings. This feature is restricted to administrators.",
+    });
+    return;
+  }
+
+  if (!mappingId) {
+    await sendNotification({
+      modify: modify,
+      user: user,
+      room: room,
+      message: `❌ **Missing mapping ID**\n\nUsage: \`/code-review-agent username ${action} <mapping_id>${action === 'reject' ? ' [reason]' : ''}\``,
+    });
+    return;
+  }
+
+  try {
+    // Verify the mapping exists
+    const pendingMapping = await PendingUserMappingPersistence.getPendingUserMapping(mappingId, persistenceRead);
+
+    if (!pendingMapping) {
+      await sendNotification({
+        modify: modify,
+        user: user,
+        room: room,
+        message: `❌ **Mapping not found**\n\nNo pending username mapping found for ID: \`${mappingId}\``,
+      });
+      return;
+    }
+
+    if (pendingMapping.status !== "pending") {
+      await sendNotification({
+        modify: modify,
+        user: user,
+        room: room,
+        message: `❌ **Mapping already reviewed**\n\nMapping for @${pendingMapping.githubUsername} was already ${pendingMapping.status} by ${pendingMapping.reviewedBy || "unknown"}`,
+      });
+      return;
+    }
+
+    if (action === "approve") {
+      // Double-check that GitHub username isn't already mapped
+      const existingMapping = await UserMappingPersistence.getUserMappingByGithubUsername(pendingMapping.githubUsername, persistenceRead);
+      if (existingMapping) {
+        await sendNotification({
+          modify: modify,
+          user: user,
+          room: room,
+          message: `❌ **Cannot approve: GitHub username already mapped**\n\nThe GitHub username @${pendingMapping.githubUsername} is now linked to another user. Please reject this request.`,
+        });
+        return;
+      }
+
+      // Create the actual user mapping
+      const userMapping: UserMapping = {
+        rcUserId: pendingMapping.rocketchatUserId,
+        rcUsername: pendingMapping.rocketchatUsername,
+        githubUsername: pendingMapping.githubUsername,
+        createdAt: new Date(),
+        lastUsed: new Date(),
+      };
+
+      await UserMappingPersistence.saveUserMapping(userMapping, persistence);
+
+      // Notify the user of approval
+      const targetUser = await read.getUserReader().getById(pendingMapping.rocketchatUserId);
+      if (targetUser) {
+        await sendDirectMessage({
+          read: read,
+          modify: modify,
+          user: targetUser,
+          message: `✅ **GitHub username mapping approved!**\n\nYour RocketChat account has been successfully linked with GitHub user @${pendingMapping.githubUsername}.\n\nYou will now receive notifications when you're assigned as a reviewer for pull requests.`,
+          persistence: persistence,
+        });
+      }
+    } else {
+      // Reject action
+      const reason = rejectionReason || "No reason provided";
+      
+      // Notify the user of rejection
+      const targetUser = await read.getUserReader().getById(pendingMapping.rocketchatUserId);
+      if (targetUser) {
+        await sendDirectMessage({
+          read: read,
+          modify: modify,
+          user: targetUser,
+          message: `❌ **GitHub username mapping rejected**\n\nYour request to link with GitHub user @${pendingMapping.githubUsername} has been rejected.\n\n**Reason:** ${reason}\n\nYou can submit a new request with a different GitHub username if needed.`,
+          persistence: persistence,
+        });
+      }
+    }
+
+    // Update the pending mapping status
+    await PendingUserMappingPersistence.updatePendingUserMappingStatus(
+      mappingId,
+      action === "approve" ? "approved" : "rejected",
+      user.id,
+      persistence,
+      persistenceRead,
+      action === "reject" ? rejectionReason : undefined
+    );
+
+    const actionMessages = {
+      approve: "✅ **Username Mapping Approved**",
+      reject: "❌ **Username Mapping Rejected**",
+    };
+
+    const actionDescriptions = {
+      approve: "The user mapping has been created and the user has been notified.",
+      reject: `The mapping request has been rejected. Reason: ${rejectionReason || "No reason provided"}`,
+    };
+
+    await sendNotification({
+      modify: modify,
+      user: user,
+      room: room,
+      message: `${actionMessages[action]}
+
+**RocketChat User:** @${pendingMapping.rocketchatUsername}
+**GitHub User:** @${pendingMapping.githubUsername}
+**GitHub Profile:** ${pendingMapping.githubMetadata.htmlUrl}
+
+${actionDescriptions[action]}`,
+    });
+
+    app.getLogger().info(`Admin ${user.username} ${action}ed username mapping: ${pendingMapping.rocketchatUsername} -> @${pendingMapping.githubUsername}`);
+
+  } catch (error) {
+    app.getLogger().error(`Failed to ${action} username mapping ${mappingId}: ${error.message}`);
+    await sendNotification({
+      modify: modify,
+      user: user,
+      room: room,
+      message: `❌ **Error processing username mapping ${action}:** ${error.message}`,
+    });
+  }
+}
+
+/**
+ * Show username command help
+ */
+async function handleUsernameHelp(
+  modify: IModify,
+  user: IUser,
+  room: IRoom
+): Promise<void> {
+  const isAdmin = isUserHighHierarchy(user);
+
+  const adminCommands = isAdmin
+    ? `
+
+**🔧 Admin Commands:**
+\`/code-review-agent username\` or \`/code-review-agent username list\` - List pending requests
+\`/code-review-agent username approve <id>\` - Approve a mapping request
+\`/code-review-agent username reject <id> [reason]\` - Reject a mapping request`
+    : "";
+
+  const helpMessage = `👤 **Username Mapping Commands**
+
+**📝 Submit GitHub username:**
+\`/code-review-agent username <github-username>\` - Submit your GitHub username for admin review
+
+**📋 Examples:**
+\`/code-review-agent username octocat\`${adminCommands}
+
+**ℹ️ About:**
+This allows you to link your GitHub account without OAuth authorization. Your request will be reviewed by administrators who can verify your identity before approving the mapping.
+
+**📧 Notifications:**
+You'll receive a direct message when your request is approved or rejected.`;
+
+  await sendNotification({
+    modify: modify,
+    user: user,
+    room: room,
+    message: helpMessage,
+  });
+}
+
+/**
+ * Build message for mapping list
+ */
+function buildMappingListMessage(pendingMappings: PendingUserMapping[]): string {
+  const count = pendingMappings.length;
+  const header = `👥 **${count} Pending Username Mapping${count === 1 ? "" : "s"}**\n\n`;
+
+  const mappings = pendingMappings
+    .slice(0, 10)
+    .map((mapping, index) => {
+      const accountAge = new Date(mapping.githubMetadata.createdAt).toLocaleDateString();
+      return `**${index + 1}.** @${mapping.rocketchatUsername} → @${mapping.githubMetadata.name || mapping.githubUsername}
+   🐙 GitHub: @${mapping.githubUsername} (${mapping.githubMetadata.publicRepos} repos, ${mapping.githubMetadata.followers} followers)
+   📅 Account created: ${accountAge} | 🏢 ${mapping.githubMetadata.company || 'No company'}
+   🔗 ${mapping.githubMetadata.htmlUrl}
+   📋 **ID:** \`${mapping.id}\``;
+    })
+    .join("\n\n");
+
+  const footer = count > 10 ? `\n\n*Showing first 10 of ${count} pending requests*` : "";
+
+  return (
+    header +
+    mappings +
+    footer +
+    "\n\n*Use the action buttons below or commands to review these requests.*"
+  );
+}
+
+/**
+ * Build interactive blocks for mapping list
+ */
+function buildMappingListBlocks(pendingMappings: PendingUserMapping[]): LayoutBlock[] {
+  const blocks: LayoutBlock[] = [
+    getSectionBlock(
+      `👥 **${pendingMappings.length} Pending Username Mapping${
+        pendingMappings.length === 1 ? "" : "s"
+      }**`
+    ),
+  ];
+
+  // Show first 5 items with action buttons
+  const itemsToShow = pendingMappings.slice(0, 5);
+
+  itemsToShow.forEach((mapping, index) => {
+    const accountAge = new Date(mapping.githubMetadata.createdAt).toLocaleDateString();
+    
+    blocks.push(
+      getSectionBlock(
+        `**${index + 1}. @${mapping.rocketchatUsername}** → **@${mapping.githubUsername}**\n` +
+        `👤 ${mapping.githubMetadata.name || mapping.githubUsername} | 🏢 ${mapping.githubMetadata.company || 'No company'}\n` +
+        `🐙 ${mapping.githubMetadata.publicRepos} repos, ${mapping.githubMetadata.followers} followers | 📅 ${accountAge}\n` +
+        `🆔 **ID:** \`${mapping.id}\``,
+        getButton({
+          labelText: "View GitHub",
+          actionId: `view_github_${mapping.id}`,
+          url: mapping.githubMetadata.htmlUrl,
+        })
+      ),
+
+      getActionsBlock(`username_actions_${mapping.id}`, [
+        getButton({
+          labelText: "✅ Approve",
+          actionId: `approve_username_${mapping.id}`,
+          value: `approve_${mapping.id}`,
+          style: "primary",
+        }),
+        getButton({
+          labelText: "❌ Reject",
+          actionId: `reject_username_${mapping.id}`,
+          value: `reject_${mapping.id}`,
+          style: "danger",
+        }),
+      ])
+    );
+
+    if (index < itemsToShow.length - 1) {
+      blocks.push(getDividerBlock());
+    }
+  });
+
+  if (pendingMappings.length > 5) {
+    blocks.push(
+      getContextBlock(
+        `*Showing first 5 of ${pendingMappings.length} pending requests. Use \`/code-review-agent username list\` to see all.*`
+      )
+    );
+  }
+
+  return blocks;
+} 

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -4,9 +4,9 @@ export enum AppSettingsEnum {
     OWNER_NAME_ID = 'owner_name',
     REPOSITORIES_LIST_ID = 'repositories_list',
     ORG_ADMIN_PAT_TOKEN_ID = 'org_admin_pat_token',
-    GEMINI_API_KEY_ID = 'gemini_api_key',
-    GEMINI_MODEL_ID = 'gemini_model',
-    GEMINI_BASE_URL_ID = 'gemini_base_url',
+    AI_PROVIDER_API_KEY_ID = 'ai_provider_api_key',
+    AI_MODEL_ID = 'ai_model',
+    AI_PROVIDER_BASE_URL_ID = 'ai_provider_base_url',
 }
 
 export const settings: Array<ISetting> = [
@@ -39,35 +39,41 @@ export const settings: Array<ISetting> = [
         i18nDescription: 'Personal Access Token with repo access for the organization'
     },
     {
-        id: AppSettingsEnum.GEMINI_API_KEY_ID,
+        id: AppSettingsEnum.AI_PROVIDER_API_KEY_ID,
         type: SettingType.PASSWORD,
         packageValue: '',
         required: true,
         public: false,
-        i18nLabel: 'Gemini API Key',
-        i18nDescription: 'Google Gemini API key for AI-powered analysis'
+        i18nLabel: 'AI Provider API Key',
+        i18nDescription: 'API key for your AI provider (OpenAI, Gemini, Claude, etc.)'
     },
     {
-        id: AppSettingsEnum.GEMINI_MODEL_ID,
+        id: AppSettingsEnum.AI_MODEL_ID,
         type: SettingType.SELECT,
-        packageValue: 'gemini-1.5-flash',
+        packageValue: 'gpt-3.5-turbo',
         required: true,
         public: false,
-        i18nLabel: 'Gemini Model',
-        i18nDescription: 'Gemini model to use for analysis',
+        i18nLabel: 'AI Model',
+        i18nDescription: 'AI model to use for analysis',
         values: [
+            { key: 'gpt-4-turbo-preview', i18nLabel: 'GPT-4 Turbo' },
+            { key: 'gpt-4', i18nLabel: 'GPT-4' },
+            { key: 'gpt-3.5-turbo', i18nLabel: 'GPT-3.5 Turbo' },
+            { key: 'claude-3-opus-20240229', i18nLabel: 'Claude 3 Opus' },
+            { key: 'claude-3-sonnet-20240229', i18nLabel: 'Claude 3 Sonnet' },
+            { key: 'claude-opus-4-20250514', i18nLabel: 'Claude Opus 4' },
             { key: 'gemini-1.5-pro', i18nLabel: 'Gemini 1.5 Pro' },
             { key: 'gemini-1.5-flash', i18nLabel: 'Gemini 1.5 Flash' },
-            { key: 'gemini-pro', i18nLabel: 'Gemini Pro' }
+            { key: 'custom', i18nLabel: 'Custom Model (specify in description)' }
         ]
     },
     {
-        id: AppSettingsEnum.GEMINI_BASE_URL_ID,
+        id: AppSettingsEnum.AI_PROVIDER_BASE_URL_ID,
         type: SettingType.STRING,
-        packageValue: 'https://generativelanguage.googleapis.com/v1beta',
+        packageValue: '',
         required: true,
         public: false,
-        i18nLabel: 'Gemini API Base URL',
-        i18nDescription: 'Base URL for Gemini API (usually https://generativelanguage.googleapis.com/v1beta)'
+        i18nLabel: 'AI Provider Base URL',
+        i18nDescription: 'Base URL for your AI provider\'s OpenAI-compatible API endpoint. Examples: https://api.openai.com/v1 (OpenAI), https://generativelanguage.googleapis.com/v1beta/openai (Gemini), https://api.anthropic.com/v1 (Claude)'
     }
 ];

--- a/src/handlers/onPreSettingUpdateHandler.ts
+++ b/src/handlers/onPreSettingUpdateHandler.ts
@@ -31,7 +31,7 @@ export async function handleOnPreSettingUpdate(
       }
       break;
     }
-    case AppSettingsEnum.GEMINI_API_KEY_ID: {
+    case AppSettingsEnum.AI_PROVIDER_API_KEY_ID: {
       if (!ValidationHelper.isValidApiKey(value)) {
         return context.oldSetting;
       }

--- a/src/handlers/onSettingUpdatedHandler.ts
+++ b/src/handlers/onSettingUpdatedHandler.ts
@@ -13,7 +13,7 @@ export async function handleOnSettingUpdated(
   read: IRead,
   http: IHttp,
   logger: ILogger,
-  clearGeminiServices: () => void,
+  clearAIServices: () => void,
   clearGitHubServices: () => void
 ): Promise<void> {
   switch (setting.id) {
@@ -44,12 +44,12 @@ export async function handleOnSettingUpdated(
         );
       }
       break;
-    case AppSettingsEnum.GEMINI_API_KEY_ID:
-    case AppSettingsEnum.GEMINI_BASE_URL_ID:
-    case AppSettingsEnum.GEMINI_MODEL_ID:
-      clearGeminiServices();
+    case AppSettingsEnum.AI_PROVIDER_API_KEY_ID:
+    case AppSettingsEnum.AI_PROVIDER_BASE_URL_ID:
+    case AppSettingsEnum.AI_MODEL_ID:
+      clearAIServices();
       logger.info(
-        `Gemini setting '${setting.id}' updated, cleared dependent services`
+        `AI setting '${setting.id}' updated, cleared dependent services`
       );
       break;
     case AppSettingsEnum.ORG_ADMIN_PAT_TOKEN_ID:

--- a/src/interfaces/IAppInterface.ts
+++ b/src/interfaces/IAppInterface.ts
@@ -8,7 +8,7 @@ import type {
 import type { IOAuth2Client } from "@rocket.chat/apps-engine/definition/oauth2/IOAuth2";
 import { PRService } from "../services/PRService";
 import { GitHubAPIService } from "../services/GitHubAPIService";
-import { GeminiService } from "../services/GeminiService";
+import { AIService } from "../services/AIService";
 import { CodeownersService } from "../services/CodeownersService";
 import { SpamDetectionService } from "../services/SpamDetectionService";
 import { ReviewerMatchingService } from "../services/ReviewerMatchingService";
@@ -19,7 +19,7 @@ export interface IAppInterface {
   getOauth2ClientInstance(): IOAuth2Client;
   getPRService(): PRService;
   getGitHubService(): GitHubAPIService;
-  getGeminiService(): GeminiService;
+  getAIService(): AIService;
   getCodeownersService(): CodeownersService;
   getSpamDetectionService(): SpamDetectionService;
   getReviewerMatchingService(): ReviewerMatchingService;

--- a/src/persistence/PendingUserMappingPersistence.ts
+++ b/src/persistence/PendingUserMappingPersistence.ts
@@ -1,0 +1,106 @@
+import { IPersistence, IPersistenceRead } from '@rocket.chat/apps-engine/definition/accessors';
+import { RocketChatAssociationModel, RocketChatAssociationRecord } from '@rocket.chat/apps-engine/definition/metadata';
+
+export interface PendingUserMapping {
+    id: string;
+    rocketchatUserId: string;
+    rocketchatUsername: string;
+    githubUsername: string;
+    githubUserId: number;
+    githubMetadata: {
+        name?: string;
+        company?: string;
+        location?: string;
+        bio?: string;
+        publicRepos: number;
+        followers: number;
+        following: number;
+        createdAt: string;
+        avatarUrl: string;
+        htmlUrl: string;
+    };
+    status: 'pending' | 'approved' | 'rejected';
+    requestedAt: Date;
+    reviewedAt?: Date;
+    reviewedBy?: string;
+    rejectionReason?: string;
+}
+
+export class PendingUserMappingPersistence {
+    private static readonly PENDING_USER_MAPPING_ASSOCIATION_KEY = 'code-review-pending-user-mapping';
+
+    // ✅ WRITE operations
+    static async savePendingUserMapping(mapping: PendingUserMapping, persistenceWrite: IPersistence): Promise<void> {
+        const association = new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            `${this.PENDING_USER_MAPPING_ASSOCIATION_KEY}:${mapping.id}`
+        );
+        await persistenceWrite.updateByAssociation(association, mapping, true);
+    }
+
+    static async updatePendingUserMappingStatus(
+        id: string,
+        status: PendingUserMapping['status'],
+        reviewedBy: string,
+        persistenceWrite: IPersistence,
+        persistenceRead: IPersistenceRead,
+        rejectionReason?: string
+    ): Promise<void> {
+        const existingMapping = await this.getPendingUserMapping(id, persistenceRead);
+        if (existingMapping) {
+            const updatedMapping = {
+                ...existingMapping,
+                status,
+                reviewedBy,
+                reviewedAt: new Date(),
+                rejectionReason
+            };
+            await this.savePendingUserMapping(updatedMapping, persistenceWrite);
+        }
+    }
+
+    static async deletePendingUserMapping(id: string, persistenceWrite: IPersistence): Promise<void> {
+        const association = new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            `${this.PENDING_USER_MAPPING_ASSOCIATION_KEY}:${id}`
+        );
+        await persistenceWrite.removeByAssociation(association);
+    }
+
+    // ✅ READ operations
+    static async getPendingUserMapping(id: string, persistenceRead: IPersistenceRead): Promise<PendingUserMapping | null> {
+        const association = new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            `${this.PENDING_USER_MAPPING_ASSOCIATION_KEY}:${id}`
+        );
+        const result = await persistenceRead.readByAssociation(association);
+        if (result.length > 0) {
+            return result[0] as PendingUserMapping;
+        }
+        return null;
+    }
+
+    static async getPendingUserMappings(persistenceRead: IPersistenceRead): Promise<PendingUserMapping[]> {
+        const allMappings = await this.getAllPendingUserMappings(persistenceRead);
+        return allMappings.filter(mapping => mapping.status === 'pending');
+    }
+
+    static async getAllPendingUserMappings(persistenceRead: IPersistenceRead): Promise<PendingUserMapping[]> {
+        const association = new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            this.PENDING_USER_MAPPING_ASSOCIATION_KEY
+        );
+        const results = await persistenceRead.readByAssociations([association]);
+        return results ? results as PendingUserMapping[] : [];
+    }
+
+    static async getPendingUserMappingByRocketChatUserId(rcUserId: string, persistenceRead: IPersistenceRead): Promise<PendingUserMapping | null> {
+        const allMappings = await this.getAllPendingUserMappings(persistenceRead);
+        return allMappings.find(mapping => mapping.rocketchatUserId === rcUserId && mapping.status === 'pending') || null;
+    }
+
+    static async getPendingUserMappingByGithubUsername(githubUsername: string, persistenceRead: IPersistenceRead): Promise<PendingUserMapping | null> {
+        const allMappings = await this.getAllPendingUserMappings(persistenceRead);
+        return allMappings.find(mapping => mapping.githubUsername === githubUsername && mapping.status === 'pending') || null;
+    }
+} 

--- a/src/services/AIService.ts
+++ b/src/services/AIService.ts
@@ -2,39 +2,44 @@ import { IHttp, IHttpResponse } from '@rocket.chat/apps-engine/definition/access
 import { CodeReviewAgentApp } from '../../CodeReviewAgentApp';
 import { AppSettingsEnum } from '../config/settings';
 
-export interface GeminiRequest {
-    contents: Array<{
-        parts: Array<{
-            text: string;
-        }>;
-    }>;
-    generationConfig?: {
-        temperature?: number;
-        topK?: number;
-        topP?: number;
-        maxOutputTokens?: number;
-        stopSequences?: string[];
-    };
+// OpenAI-compatible request/response interfaces
+export interface ChatCompletionMessage {
+    role: 'system' | 'user' | 'assistant';
+    content: string;
 }
 
-export interface GeminiResponse {
-    candidates: Array<{
-        content: {
-            parts: Array<{
-                text: string;
-            }>;
-        };
-        finishReason: string;
+export interface ChatCompletionRequest {
+    model: string;
+    messages: ChatCompletionMessage[];
+    temperature?: number;
+    max_tokens?: number;
+    top_p?: number;
+    frequency_penalty?: number;
+    presence_penalty?: number;
+    stop?: string | string[];
+}
+
+export interface ChatCompletionResponse {
+    id: string;
+    object: string;
+    created: number;
+    model: string;
+    choices: Array<{
         index: number;
+        message: {
+            role: string;
+            content: string;
+        };
+        finish_reason: string;
     }>;
-    usageMetadata?: {
-        promptTokenCount: number;
-        candidatesTokenCount: number;
-        totalTokenCount: number;
+    usage?: {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
     };
 }
 
-export interface GeminiAnalysisResult {
+export interface AIAnalysisResult {
     success: boolean;
     result?: any;
     reasoning?: string;
@@ -46,94 +51,107 @@ export interface GeminiAnalysisResult {
     };
 }
 
-export class GeminiService {
+export class AIService {
     constructor(private app: CodeReviewAgentApp) {}
 
     private async getApiConfig(): Promise<{ apiKey: string; baseUrl: string; model: string }> {
         const settings = this.app.getAccessors().environmentReader.getSettings();
         
-        const apiKey = await settings.getValueById(AppSettingsEnum.GEMINI_API_KEY_ID);
-        const baseUrl = await settings.getValueById(AppSettingsEnum.GEMINI_BASE_URL_ID);
-        const model = await settings.getValueById(AppSettingsEnum.GEMINI_MODEL_ID);
+        const apiKey = await settings.getValueById(AppSettingsEnum.AI_PROVIDER_API_KEY_ID);
+        const baseUrl = await settings.getValueById(AppSettingsEnum.AI_PROVIDER_BASE_URL_ID);
+        const model = await settings.getValueById(AppSettingsEnum.AI_MODEL_ID);
         
         if (!apiKey) {
-            throw new Error('Gemini API key not configured');
+            throw new Error('AI provider API key not configured');
+        }
+        
+        if (!baseUrl) {
+            throw new Error('AI provider base URL not configured');
         }
         
         return { apiKey, baseUrl, model };
     }
 
-    public async makeGeminiRequest(
+    public async makeAIRequest(
         prompt: string, 
         systemInstruction?: string,
-        config?: Partial<GeminiRequest['generationConfig']>
-    ): Promise<GeminiAnalysisResult> {
+        config?: {
+            temperature?: number;
+            maxTokens?: number;
+            topP?: number;
+        }
+    ): Promise<AIAnalysisResult> {
         try {
             const { apiKey, baseUrl, model } = await this.getApiConfig();
             const httpClient = this.app.getAccessors().http;
             
-            // Prepare the content with system instruction if provided
-            const contents: Array<{ parts: Array<{ text: string }> }> = [];
+            // Build messages array in OpenAI format
+            const messages: ChatCompletionMessage[] = [];
             
             if (systemInstruction) {
-                contents.push({
-                    parts: [{ text: systemInstruction }]
+                messages.push({
+                    role: 'system',
+                    content: systemInstruction
                 });
             }
             
-            contents.push({
-                parts: [{ text: prompt }]
+            messages.push({
+                role: 'user',
+                content: prompt
             });
 
-            const requestBody: GeminiRequest = {
-                contents,
-                generationConfig: {
-                    temperature: 0.7,
-                    topK: 40,
-                    topP: 0.95,
-                    maxOutputTokens: 2048,
-                    ...config
-                }
+            const requestBody: ChatCompletionRequest = {
+                model,
+                messages,
+                temperature: config?.temperature ?? 0.7,
+                max_tokens: config?.maxTokens ?? 2048,
+                top_p: config?.topP ?? 0.95
             };
 
-            const url = `${baseUrl}/models/${model}:generateContent?key=${apiKey}`;
+            // Ensure baseUrl ends with /v1 for OpenAI compatibility
+            const normalizedBaseUrl = baseUrl.endsWith('/v1') || baseUrl.endsWith('/v1/') 
+                ? baseUrl.replace(/\/$/, '') 
+                : `${baseUrl.replace(/\/$/, '')}/v1`;
+            
+            const url = `${normalizedBaseUrl}/chat/completions`;
             
             const response: IHttpResponse = await httpClient.post(url, {
                 headers: {
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${apiKey}`
                 },
                 data: requestBody
             });
 
             if (response.statusCode !== 200) {
-                throw new Error(`Gemini API error: ${response.statusCode} - ${response.content}`);
+                throw new Error(`AI API error: ${response.statusCode} - ${response.content}`);
             }
 
-            const geminiResponse = response.data as GeminiResponse;
+            const aiResponse = response.data as ChatCompletionResponse;
             
-            if (!geminiResponse.candidates || geminiResponse.candidates.length === 0) {
-                throw new Error('No response candidates from Gemini API');
+            if (!aiResponse.choices || aiResponse.choices.length === 0) {
+                throw new Error('No response choices from AI API');
             }
 
-            const candidate = geminiResponse.candidates[0];
-            if (!candidate.content || !candidate.content.parts || candidate.content.parts.length === 0) {
-                throw new Error('Invalid response structure from Gemini API');
+            const choice = aiResponse.choices[0];
+            if (!choice.message || !choice.message.content) {
+                throw new Error('Invalid response structure from AI API');
             }
 
-            const responseText = candidate.content.parts[0].text;
+            const responseText = choice.message.content;
 
             return {
                 success: true,
                 result: responseText,
-                tokenUsage: geminiResponse.usageMetadata ? {
-                    promptTokens: geminiResponse.usageMetadata.promptTokenCount,
-                    completionTokens: geminiResponse.usageMetadata.candidatesTokenCount,
-                    totalTokens: geminiResponse.usageMetadata.totalTokenCount
+                tokenUsage: aiResponse.usage ? {
+                    promptTokens: aiResponse.usage.prompt_tokens,
+                    completionTokens: aiResponse.usage.completion_tokens,
+                    totalTokens: aiResponse.usage.total_tokens
                 } : undefined
             };
 
         } catch (error) {
-            this.app.getLogger().error(`Gemini API request failed: ${error.message}`);
+            this.app.getLogger().error(`AI API request failed: ${error.message}`);
             return {
                 success: false,
                 error: error.message
@@ -153,7 +171,7 @@ export class GeminiService {
         };
         filesChanged: string[];
         diffSummary: string;
-    }): Promise<GeminiAnalysisResult> {
+    }): Promise<AIAnalysisResult> {
         const systemInstruction = `You are a code review assistant that analyzes pull requests for spam probability. 
         
 Analyze the provided PR data and return a JSON response with:
@@ -191,9 +209,9 @@ ${prData.diffSummary}
 
 Provide your analysis as JSON only.`;
 
-        const result = await this.makeGeminiRequest(prompt, systemInstruction, {
-            temperature: 0.3, // Lower temperature for more consistent analysis
-            maxOutputTokens: 1024
+        const result = await this.makeAIRequest(prompt, systemInstruction, {
+            temperature: 0.2,
+            maxTokens: 1024
         });
 
         if (result.success) {
@@ -212,7 +230,7 @@ Provide your analysis as JSON only.`;
                     throw new Error('No JSON found in response');
                 }
             } catch (parseError) {
-                this.app.getLogger().warn(`Failed to parse Gemini JSON response: ${parseError.message}`);
+                this.app.getLogger().warn(`Failed to parse AI JSON response: ${parseError.message}`);
                 return {
                     success: false,
                     error: `Failed to parse analysis: ${parseError.message}`
@@ -231,7 +249,7 @@ Provide your analysis as JSON only.`;
         codeowners: { [filePath: string]: string[] };
         commitHistory: { [filePath: string]: Array<{ author: string; commits: number; lastCommit: string }> };
         potentialReviewers: string[];
-    }): Promise<GeminiAnalysisResult> {
+    }): Promise<AIAnalysisResult> {
         const systemInstruction = `You are a code review assistant that finds the best reviewers for pull requests.
 
 Analyze the provided data and return a JSON response with top 3 reviewers:
@@ -281,9 +299,9 @@ ${prData.potentialReviewers.join(', ')}
 
 Provide your analysis as JSON only with the top 3 reviewers ranked by suitability.`;
 
-        const result = await this.makeGeminiRequest(prompt, systemInstruction, {
+        const result = await this.makeAIRequest(prompt, systemInstruction, {
             temperature: 0.4,
-            maxOutputTokens: 1536
+            maxTokens: 1536
         });
 
         if (result.success) {
@@ -301,7 +319,7 @@ Provide your analysis as JSON only with the top 3 reviewers ranked by suitabilit
                     throw new Error('No JSON found in response');
                 }
             } catch (parseError) {
-                this.app.getLogger().warn(`Failed to parse Gemini JSON response: ${parseError.message}`);
+                this.app.getLogger().warn(`Failed to parse AI JSON response: ${parseError.message}`);
                 return {
                     success: false,
                     error: `Failed to parse analysis: ${parseError.message}`
@@ -311,4 +329,4 @@ Provide your analysis as JSON only with the top 3 reviewers ranked by suitabilit
 
         return result;
     }
-}
+} 

--- a/src/services/ReviewerMatchingService.ts
+++ b/src/services/ReviewerMatchingService.ts
@@ -1,5 +1,5 @@
 import { CodeReviewAgentApp } from '../../CodeReviewAgentApp';
-import { GeminiService } from './GeminiService';
+import { AIService } from './AIService';
 import { GitHubAPIService, GitHubPullRequest, GitHubCommit } from './GitHubAPIService';
 import { CodeownersService } from './CodeownersService';
 import { UserMappingPersistence, UserMapping } from '../persistence/UserMappingPersistence';
@@ -27,12 +27,12 @@ export interface ReviewerAnalysisData {
 }
 
 export class ReviewerMatchingService {
-    private geminiService: GeminiService;
+    private aiService: AIService;
     private githubService: GitHubAPIService;
     private codeownersService: CodeownersService;
 
     constructor(private app: CodeReviewAgentApp) {
-        this.geminiService = app.getGeminiService();
+        this.aiService = app.getAIService();
         this.githubService = app.getGitHubService();
         this.codeownersService = app.getCodeownersService();
     }
@@ -47,11 +47,11 @@ export class ReviewerMatchingService {
             // Gather analysis data
             const analysisData = await this.gatherReviewerAnalysisData(persistenceRead, pr, repoName);
             
-            // Use Gemini to analyze and rank reviewers
-            const geminiRecommendations = await this.performGeminiReviewerAnalysis(analysisData);
+            // Use AI to analyze and rank reviewers
+            const aiRecommendations = await this.performAIReviewerAnalysis(analysisData);
             
             // Enhance with RC account mapping and metadata
-            const enhancedRecommendations = await this.enhanceWithMetadata(persistenceRead, geminiRecommendations);
+            const enhancedRecommendations = await this.enhanceWithMetadata(persistenceRead, aiRecommendations);
             
             // Return top 3, prioritizing those with RC accounts
             const sortedRecommendations = this.prioritizeAndSort(enhancedRecommendations);
@@ -167,9 +167,9 @@ export class ReviewerMatchingService {
     }
 
     /**
-     * Use Gemini to analyze and rank potential reviewers
+     * Use AI to analyze and rank potential reviewers
      */
-    private async performGeminiReviewerAnalysis(data: ReviewerAnalysisData): Promise<ReviewerRecommendation[]> {
+    private async performAIReviewerAnalysis(data: ReviewerAnalysisData): Promise<ReviewerRecommendation[]> {
         const systemInstruction = `You are an expert at matching code reviewers to pull requests in open source projects.
 
 Your task is to analyze the PR and potential reviewers, then recommend the top reviewers based on:
@@ -224,9 +224,9 @@ Rank these reviewers by their suitability to review this specific PR. Consider:
 
 Provide detailed reasoning for each recommendation.`;
 
-        const result = await this.geminiService.makeGeminiRequest(prompt, systemInstruction, {
+        const result = await this.aiService.makeAIRequest(prompt, systemInstruction, {
             temperature: 0.3,
-            maxOutputTokens: 2048
+            maxTokens: 2048
         });
 
         if (result.success) {
@@ -261,14 +261,14 @@ Provide detailed reasoning for each recommendation.`;
                         };
                     });
                 } else {
-                    throw new Error('No JSON array found in Gemini response');
+                    throw new Error('No JSON array found in AI response');
                 }
             } catch (parseError) {
-                this.app.getLogger().warn(`Failed to parse Gemini reviewer analysis: ${parseError.message}`);
+                this.app.getLogger().warn(`Failed to parse AI reviewer analysis: ${parseError.message}`);
                 throw new Error(`Analysis parsing failed: ${parseError.message}`);
             }
         } else {
-            throw new Error(`Gemini analysis failed: ${result.error}`);
+            throw new Error(`AI analysis failed: ${result.error}`);
         }
     }
 
@@ -349,13 +349,13 @@ Provide detailed reasoning for each recommendation.`;
                 return a.codeownersMatch ? -1 : 1;
             }
             
-            // Tertiary: Gemini score
+            // Tertiary: AI score
             return b.score - a.score;
         });
     }
 
     /**
-     * Fallback recommendations when Gemini analysis fails
+     * Fallback recommendations when AI analysis fails
      */
     private async getFallbackReviewers(persistenceRead: IPersistenceRead, pr: GitHubPullRequest, repoName: string): Promise<ReviewerRecommendation[]> {
         this.app.getLogger().info(`Using fallback reviewer selection for PR #${pr.number}`);

--- a/src/services/SpamDetectionService.ts
+++ b/src/services/SpamDetectionService.ts
@@ -1,5 +1,5 @@
 import { CodeReviewAgentApp } from '../../CodeReviewAgentApp';
-import { GeminiService } from './GeminiService';
+import { AIService } from './AIService';
 import { GitHubAPIService, GitHubPullRequest } from './GitHubAPIService';
 import { PRPersistence, StoredPR } from '../persistence/PRPersistence';
 import { SpamReviewPersistence, SpamReviewItem } from '../persistence/SpamReviewPersistence';
@@ -24,11 +24,11 @@ export interface PRAnalysisData {
 }
 
 export class SpamDetectionService {
-    private geminiService: GeminiService;
+    private aiService: AIService;
     private githubService: GitHubAPIService;
 
     constructor(private app: CodeReviewAgentApp) {
-        this.geminiService = app.getGeminiService();
+        this.aiService = app.getAIService();
         this.githubService = app.getGitHubService();
     }
 
@@ -42,8 +42,8 @@ export class SpamDetectionService {
             // Gather comprehensive PR data
             const analysisData = await this.gatherPRAnalysisData(pr, repoName);
             
-            // Perform Gemini-based spam analysis
-            const spamResult = await this.performGeminiSpamAnalysis(analysisData);
+                    // Perform AI-based spam analysis
+        const spamResult = await this.performAISpamAnalysis(analysisData);
             
             // If spam detected, queue for admin review
             if (spamResult.isSpam) {
@@ -101,9 +101,9 @@ export class SpamDetectionService {
     }
 
     /**
-     * Use Gemini to analyze PR for spam characteristics
+     * Use AI to analyze PR for spam characteristics
      */
-    private async performGeminiSpamAnalysis(data: PRAnalysisData): Promise<SpamAnalysisResult> {
+    private async performAISpamAnalysis(data: PRAnalysisData): Promise<SpamAnalysisResult> {
         const systemInstruction = `You are an expert at detecting spam pull requests in open source repositories. 
 
 Analyze the provided PR data and identify potential spam characteristics including:
@@ -149,9 +149,9 @@ ${data.diffSummary}
 
 Provide detailed analysis focusing on red flags that indicate this might be spam.`;
 
-        const result = await this.geminiService.makeGeminiRequest(prompt, systemInstruction, {
+        const result = await this.aiService.makeAIRequest(prompt, systemInstruction, {
             temperature: 0.2, // Low temperature for consistent analysis
-            maxOutputTokens: 1024
+            maxTokens: 1024
         });
 
         if (result.success) {
@@ -181,14 +181,14 @@ Provide detailed analysis focusing on red flags that indicate this might be spam
                         isSpam
                     };
                 } else {
-                    throw new Error('No JSON found in Gemini response');
+                    throw new Error('No JSON found in AI response');
                 }
             } catch (parseError) {
-                this.app.getLogger().warn(`Failed to parse Gemini spam analysis: ${parseError.message}`);
+                this.app.getLogger().warn(`Failed to parse AI spam analysis: ${parseError.message}`);
                 throw new Error(`Analysis parsing failed: ${parseError.message}`);
             }
         } else {
-            throw new Error(`Gemini analysis failed: ${result.error}`);
+            throw new Error(`AI analysis failed: ${result.error}`);
         }
     }
 


### PR DESCRIPTION
This PR includes two major enhancements:

## 🤖 AI Service Migration
- Migrated from Gemini-specific service to provider-agnostic AI service using OpenAI API specification
- Users can now configure any AI provider (OpenAI, Gemini, Claude) by setting base URL and API key
- Updated settings to be provider-neutral with expanded model selection
- Maintains all existing spam detection and reviewer matching functionality
- Automatic base URL normalization for OpenAI compatibility

## 👤 Manual GitHub Username Mapping
- Added alternative to OAuth for linking GitHub accounts
- Users submit GitHub username via /code-review-agent username <username> for admin review
- Comprehensive validation: format checking, duplicate prevention, GitHub API verification
- Admin review interface with GitHub metadata (repos, followers, company, account age)
- Admins can approve/reject requests with reasons via /code-review-agent username approve/reject <id>
- Direct message notifications for approval/rejection results
- Full integration with existing UserMappingPersistence for approved requests

Both features improve accessibility - AI provider flexibility and non-OAuth account linking options for users who prefer manual verification over OAuth authorization.